### PR TITLE
Fixed moon icon tooltip

### DIFF
--- a/esoteria/src/App.vue
+++ b/esoteria/src/App.vue
@@ -5,6 +5,7 @@ import NavBar from './components/NavBar.vue'
 import Footer from './components/Footer.vue'
 import OpenAI from "openai";
 import axios from "axios";
+import { state } from "./state.js"
 </script>
 
 <template>
@@ -78,6 +79,7 @@ import axios from "axios";
           },
         }).then((res) => {
           this.moonPhase = res.data.data.table.rows[0].cells[0].extraInfo.phase.string;
+          state.currentPhase = this.moonPhase;
         }).catch((err) => console.error(err));
       },
       resizeCanvas() {

--- a/esoteria/src/components/Footer.vue
+++ b/esoteria/src/components/Footer.vue
@@ -1,13 +1,6 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-
-defineProps({
-  msg: {
-    type: String,
-    required: true
-  }
-})
 </script>
 
 <template>


### PR DESCRIPTION
Fixed issue #23 bug where moon icon's tooltip was appearing as "null:null". Code that updated state value with current phase was accidentally deleted (probably in a PR) so the component wasn't getting the phase data. Also removed an extraneous prop in the footer component that was causing some warnings in the console.